### PR TITLE
feat: Link FireStore Search Bar with Map

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -18,6 +18,7 @@ import { doc, getDoc } from "firebase/firestore";
 import {useEffect, useState} from "react";
 import Permissions from './components/permissions/Permissions';
 import { AddLocation, Map as MapIcon } from '@mui/icons-material';
+import SearchMap from './components/searchmap/SearchMap';
 
 // Checks if the current user is an admin. Returns true if isAdmin = true and 
 // false if isAdmin = false or user is not in table
@@ -55,22 +56,50 @@ function App() {
   */
   return (
     <>
-    <DashboardProvider>
-      <div className="App">
-        <Logo className="logo" />
-        <SearchBar />
-        <Button className='microphoneButton' onClick={() => {tester(user?.uid)}}>All Test</Button>
-        {user == null ? <Button className='signinButton' component={Link} to={"/signin"}>Sign in</Button>
-          : <Button className='signinButton' onClick = {signOut}>Sign Out</Button>}
-        <div className='buttonContainer'>
-          {isAdmin ? <IconButton className='addButton'><AddLocation /></IconButton> : null}
-          <ToggleButton value={heatmapToggle} onClick={() => setHeatmapToggle(!heatmapToggle)} className='addButton'><MapIcon /></ToggleButton>
+      <DashboardProvider>
+        <div className="App">
+          <Logo className="logo" />
+          <SearchMap heatmap={heatmapToggle}></SearchMap>
+          <Button
+            className="microphoneButton"
+            onClick={() => {
+              tester(user?.uid);
+            }}
+          >
+            All Test
+          </Button>
+          {user == null ? (
+            <Button className="signinButton" component={Link} to={"/signin"}>
+              Sign in
+            </Button>
+          ) : (
+            <Button className="signinButton" onClick={signOut}>
+              Sign Out
+            </Button>
+          )}
+          <div className="buttonContainer">
+            {isAdmin ? (
+              <IconButton className="addButton">
+                <AddLocation />
+              </IconButton>
+            ) : null}
+            <ToggleButton
+              value={heatmapToggle}
+              onClick={() => setHeatmapToggle(!heatmapToggle)}
+              className="addButton"
+            >
+              <MapIcon />
+            </ToggleButton>
+          </div>
+          <Permissions />
+          <Dashboard
+            locationName="ELTC"
+            location="53.527172826716836, -113.53013883407911"
+            capacity={50}
+            description="it's a place!"
+          />
         </div>
-        <Map heatmap={heatmapToggle}/>
-        <Permissions />
-        <Dashboard locationName="ELTC" location='53.527172826716836, -113.53013883407911' capacity={50} description="it's a place!" />
-      </div>
-    </DashboardProvider>
+      </DashboardProvider>
     </>
   );
 }

--- a/app/src/components/map/Map.tsx
+++ b/app/src/components/map/Map.tsx
@@ -1,5 +1,5 @@
-import { useCallback, useState, memo } from "react"
-import {GoogleMap, GoogleMapProps, HeatmapLayer, Libraries, useJsApiLoader} from "@react-google-maps/api"
+import { useCallback, useState, memo, useMemo } from "react"
+import {GoogleMap, GoogleMapProps, HeatmapLayer, useJsApiLoader} from "@react-google-maps/api"
 import "./index.css"
 import { LinearProgress } from "@mui/material";
 import CustomMarker from "../marker/Marker"
@@ -65,16 +65,19 @@ const Map = (props: GoogleMapProps & MapProps) => {
         }
     }, [props.heatmap, map, heatmap])
     
+    
     const { isLoaded } = useJsApiLoader({
         id: 'test-script',
         googleMapsApiKey: process.env.REACT_APP_MAP_API_KEY || '', // !!! PROD KEY IS RESTRICTED TO WEBSITE
         libraries: ['visualization'],
     });
-    // Map centered on ETLC
-    const center = {
-        lat: position.latitude || 53.52716644287327, 
+
+    const center = useMemo(() => {
+      return {
+        lat: position.latitude || 53.52716644287327,
         lng: position.longitude || -113.5302139343207,
-    };
+      };
+    }, [position]);
 
     const onLoad = useCallback((map: google.maps.Map) => {
         map.setZoom(15)

--- a/app/src/components/map/Map.tsx
+++ b/app/src/components/map/Map.tsx
@@ -19,12 +19,20 @@ interface LocationData {
 }
 
 interface MapProps {
-    heatmap: boolean
+  heatmap: boolean;
+  handleItemClick: (itemId: string) => Promise<void>;
+  position: {
+    latitude: number;
+    longitude: number;
+  };
+  map: google.maps.Map;
+  setMap: React.Dispatch<
+    React.SetStateAction<google.maps.Map | null | undefined>
+  >;
 }
 
 
 const Map = (props: GoogleMapProps & MapProps) => {
-    const [map, setMap] = useState<google.maps.Map | null>();
     const [heatmap, setHeatMap] = useState<google.maps.visualization.HeatmapLayer | null>();
     const [locations, setLocations] = useState<LocationData[] | null>(null);
     const [heatmapData, setHeatMapData] = useState<google.maps.LatLng[]>([]);
@@ -32,6 +40,7 @@ const Map = (props: GoogleMapProps & MapProps) => {
       latitude: null as unknown as number,
       longitude: null as unknown as number,
     });
+    const map = props.map;
 
     useEffect(() => {
       if ("geolocation" in navigator) {
@@ -89,11 +98,11 @@ const Map = (props: GoogleMapProps & MapProps) => {
             new window.google.maps.LatLng({lat: 53.52716644287327, lng: -113.53034307}),
             new window.google.maps.LatLng({lat: 53.52716644287327, lng: -113.5302143207}),
         ]);
-        setMap(map);
+        props.setMap(map);
     }, [center]);
 
     const onUnmount = useCallback(() => {
-        setMap(null);
+        props.setMap(null);
     }, []);
 
     const onHeatMapLoad = useCallback((heatmapLayer: google.maps.visualization.HeatmapLayer) => {

--- a/app/src/components/searchbar/SearchBar.tsx
+++ b/app/src/components/searchbar/SearchBar.tsx
@@ -4,8 +4,11 @@ import {getAllLocs} from "../../scripts/Firebase"
 import { useState, useEffect } from "react";
 import "./index.css"
 
-const SearchBar = () => {
+interface SearchBarProps {
+  handleItemClick: (itemId: string) => Promise<void>;
+}
 
+const SearchBar = (props: SearchBarProps) => {
   const [items, setItems] = useState<{ label: string; value: number }[]>([]);
 
   useEffect(() => {
@@ -20,6 +23,15 @@ const SearchBar = () => {
 
     fetchLocations();
   }, []);
+
+  const onItemClick = async (option: string) => {
+    const locs = await getAllLocs("University of Alberta");
+    locs.forEach(async (loc) => {
+      if (option === loc.data().name)
+        // console.log(loc.data().position.latitude);
+        await props.handleItemClick(option);
+    });
+  };
   // solved border issues with: https://github.com/mui/material-ui/issues/30597
   return (
     <div className="searchBar">
@@ -27,6 +39,11 @@ const SearchBar = () => {
         id="search-bar"
         options={items}
         getOptionLabel={(option) => option.label}
+        onChange={(event, newValue) => {
+          if (newValue) {
+            onItemClick(newValue.label);
+          }
+        }}
         renderInput={(params) => (
           <TextField
             {...params}
@@ -39,14 +56,14 @@ const SearchBar = () => {
                 </>
               ),
             }}
-            sx={{ 
-              "& .MuiOutlinedInput-notchedOutline":{ border: 'none' },
-             }}
+            sx={{
+              "& .MuiOutlinedInput-notchedOutline": { border: "none" },
+            }}
           />
         )}
       />
     </div>
   );
-}
+};
 
 export default SearchBar;

--- a/app/src/components/searchmap/SearchMap.tsx
+++ b/app/src/components/searchmap/SearchMap.tsx
@@ -1,0 +1,40 @@
+import { useState } from "react";
+import SearchBar from "../searchbar/SearchBar"
+import Map from "../map/Map";
+import { getAllLocs } from "../../scripts/Firebase";
+
+interface SearchMapProps {
+  heatmap: boolean;
+}
+
+const SearchMap = (props: SearchMapProps) => {
+  const [position, setPosition] = useState({ latitude: 0, longitude: 0 });
+  const [map, setMap] = useState<google.maps.Map | null>();
+
+  const handleItemClick = async (itemId: string) => {
+    const locs = await getAllLocs("University of Alberta");
+    locs.forEach((loc) => {
+      if (itemId === loc.data().name)
+        map?.setCenter({
+          lat: loc.data().position.latitude,
+          lng: loc.data().position.longitude,
+        });
+        map?.setZoom(30);
+    });
+  };
+
+  return (
+    <div>
+      <SearchBar handleItemClick={handleItemClick} />
+      <Map
+        heatmap={props.heatmap}
+        handleItemClick={handleItemClick}
+        position={position}
+        map={map!}
+        setMap={setMap}
+      />
+    </div>
+  );
+};
+
+export default SearchMap;


### PR DESCRIPTION
This PR primarily adds functionality to link the search bar with the map. Now, the search bar which previously showed items from fire store is interactive, and will go to the location of the item when clicked.

It also prettifies components, and removes unused variables.

It also includes a couple more cache implementations to improve performance.