### PR TITLE
Heatmap and dashboard graph updates

### DIFF
--- a/app/src/components/dashboard/Dashboard.tsx
+++ b/app/src/components/dashboard/Dashboard.tsx
@@ -6,7 +6,7 @@ import { ChartsXAxis } from '@mui/x-charts/ChartsXAxis'
 import LevelCard from "./LevelCard"
 import { AccountBox, Description, GpsFixed, TurnedIn, TurnedInNot } from "@mui/icons-material"
 import { useContext, useState } from "react"
-import { BarPlot, ChartsLegend } from "@mui/x-charts"
+import { BarPlot, ChartsLegend, ChartsYAxis } from "@mui/x-charts"
 import EditIcon from '@mui/icons-material/Edit';
 import { useAdminFeat } from "../admin/AdminFeatProvider"
 import { useAuth } from "../authentication/AuthProvider"
@@ -82,6 +82,13 @@ export const Dashboard = () => {
                       id: 'x-axis-id',
                     },
                   ]}
+                  yAxis={[
+                    {
+                      data: [0, 20, 40, 60, 80, 100],
+                      scaleType: 'linear',
+                      id: 'y-axis-id',
+                    }
+                  ]}
                   series={[{
                       type: 'bar',
                       data: data.loudtrend,
@@ -97,6 +104,7 @@ export const Dashboard = () => {
                       <ChartsLegend />
                       <BarPlot/>
                       <ChartsXAxis position="bottom" />
+                      <ChartsYAxis position="left" />
                 </ResponsiveChartContainer>
               </div>
             </div>


### PR DESCRIPTION
- Graph has a y-axis that ranges from 0 to 100 on a linear scale
- Heatmap draws its data from the DashboardProvider's locations array, meaning all updates here will be reflected on the heatmap.
- Heatmap draws bigger circles around location markers, which have their weight set by busyness level.
- Heatmap updates its data every thirty seconds.

![Heatmap](https://github.com/ECE-493-Group-20/ZenZone/assets/71356971/072e0455-ac1c-4cb5-b21a-616612aa1a0a)