### PR TITLE
Adds user to UserInformation table if user is missing from table

### DIFF
--- a/app/src/components/authentication/Authentication.tsx
+++ b/app/src/components/authentication/Authentication.tsx
@@ -304,7 +304,6 @@ function AdminSignUp() {
     }
   }, [user]); 
 
-  // TODO: IMPLEMENT MAKING ADMIN
   const googleSignIn = async () => {
     // Code from Firebase documentation
     const auth = getAuth();

--- a/app/src/scripts/Firebase.tsx
+++ b/app/src/scripts/Firebase.tsx
@@ -502,6 +502,9 @@ export function getUserInformation(user: string, callback: (user: UserInformatio
         onSnapshot(userDoc, (snapshot) => {
             const data = snapshot.data()
             if (!data) {
+                // missing document
+                const userInfo = db.collection("UserInformation");
+                userInfo.doc(user).set({isAdmin : false, favourites : []});
                 return
             }
             callback({


### PR DESCRIPTION
If the user is missing from the UserInformation table, the user will be added to the table when fetching user information. #110 

Users do not automatically get added to the table if they click "Continue with Google" from the sign in page. 

NOTE: this assumes non-admin users.